### PR TITLE
Dbx synchronizer upload methods

### DIFF
--- a/app/jobs/regular/sync_backups_to_dropbox.rb
+++ b/app/jobs/regular/sync_backups_to_dropbox.rb
@@ -1,10 +1,12 @@
-module Jobs  
+module Jobs
   class SyncBackupsToDropbox < ::Jobs::Base
 
   	sidekiq_options queue: 'low'
 
     def execute(args)
-      ::DiscourseBackupToDropbox::DropboxSynchronizer.sync if SiteSetting.discourse_backups_to_dropbox_enabled
+      Backup.all.take(SiteSetting.discourse_backups_to_dropbox_quantity) do |backup|
+        DropboxSynchronizer.new(backup).sync # sync inherited from base class, which results in perform_sync
+      end
     end
   end
 end

--- a/lib/dropbox_synchronizer.rb
+++ b/lib/dropbox_synchronizer.rb
@@ -38,28 +38,30 @@ module DiscourseBackupToDropbox
         @dbx.delete("/#{folder_name}/#{filename}")
       end
     end
-
-    def self.upload(@dbx, folder_name, file_name, full_path, size)
+##################################################################################
+    # renamed @dbx for dbx as we must memoize the call
+    # deleted dbx argument in both uploads because of memoization
+    def self.upload(folder_name, file_name, full_path, size)
       if size < UPLOAD_MAX_SIZE then
-        @dbx.upload("/#{folder_name}/#{file_name}", File.open(full_path, "r"))
+        dbx.upload("/#{folder_name}/#{file_name}", File.open(full_path, "r"))
       else
-        chunked_upload(@dbx, folder_name, file_name, full_path)
+        chunked_upload(dbx, folder_name, file_name, full_path)
       end
     end
 
-    def self.chunked_upload(@dbx, folder_name, file_name, full_path)
+    def self.chunked_upload(folder_name, file_name, full_path)
       File.open(full_path) do |f|
         loops = f.size / CHUNK_SIZE
 
-        cursor = @dbx.start_upload_session(f.read(CHUNK_SIZE))
+        cursor = dbx.start_upload_session(f.read(CHUNK_SIZE))
 
         (loops-1).times do |i|
-          @dbx.append_upload_session( cursor, f.read(CHUNK_SIZE) )
+          dbx.append_upload_session( cursor, f.read(CHUNK_SIZE) )
         end
 
-        @dbx.finish_upload_session(cursor, "/#{folder_name}/#{file_name}", f.read(CHUNK_SIZE))
+        dbx.finish_upload_session(cursor, "/#{folder_name}/#{file_name}", f.read(CHUNK_SIZE))
       end
     end
-
+##################################################################################
   end
 end


### PR DESCRIPTION
not so much going on here
we need the chunks because dropbox says so
[ Drobox: about chunks ](https://www.dropbox.com/developers-v1/core/docs#chunked-upload)
```

# renamed @dbx for dbx as we memoize the call
# deleted dbx argument in both upload methods because of memoization
```