### PR TITLE
upload unique files

### DIFF
--- a/app/jobs/regular/sync_backups_to_dropbox.rb
+++ b/app/jobs/regular/sync_backups_to_dropbox.rb
@@ -4,7 +4,8 @@ module Jobs
   	sidekiq_options queue: 'low'
 
     def execute(args)
-      Backup.all.take(SiteSetting.discourse_sync_to_dropbox_quantity).each do |backup|
+      backups = Backup.all.take(SiteSetting.discourse_sync_to_dropbox_quantity)
+      backups.each do |backup|
         DiscourseBackupToDropbox::DropboxSynchronizer.new(backup).sync
       end
     end

--- a/app/jobs/regular/sync_backups_to_dropbox.rb
+++ b/app/jobs/regular/sync_backups_to_dropbox.rb
@@ -4,8 +4,8 @@ module Jobs
   	sidekiq_options queue: 'low'
 
     def execute(args)
-      Backup.all.map(&:filename).take(SiteSetting.discourse_sync_to_dropbox_quantity) do |backup|
-        DiscourseBackupToDropbox::DropboxSynchronizer.new(backup).sync # sync inherited from base class, which results in perform_sync
+      Backup.all.take(SiteSetting.discourse_sync_to_dropbox_quantity).each do |backup|
+        DiscourseBackupToDropbox::DropboxSynchronizer.new(backup).sync
       end
     end
   end

--- a/app/jobs/regular/sync_backups_to_dropbox.rb
+++ b/app/jobs/regular/sync_backups_to_dropbox.rb
@@ -4,7 +4,7 @@ module Jobs
   	sidekiq_options queue: 'low'
 
     def execute(args)
-      Backup.all.take(SiteSetting.discourse_sync_to_dropbox_quantity) do |backup|
+      Backup.all.map(&:filename).take(SiteSetting.discourse_sync_to_dropbox_quantity) do |backup|
         DiscourseBackupToDropbox::DropboxSynchronizer.new(backup).sync # sync inherited from base class, which results in perform_sync
       end
     end

--- a/lib/dropbox_synchronizer.rb
+++ b/lib/dropbox_synchronizer.rb
@@ -34,17 +34,15 @@ module DiscourseBackupToDropbox
       rescue
         #folder already exists
       end
-      file_name = backup.filename
-      dbx.upload("/#{folder_name}/#{file_name}", "#{file_name}")
-      # dbx_files = dbx.list_folder("/#{folder_name}")
-      # (backup - dbx_files).each do |f|
-      #   # if f.present?
-      #     full_path  = f.path
-      #     filename   = f.filename
-      #     size       = f.size
-      #     upload(folder_name, filename, full_path, size)
-      #   # end
-      # end
+      dbx_files = dbx.list_folder("/#{folder_name}").map(&:name)
+      (backup.filename - dbx_files).each do |f|
+        if f.present?
+          full_path  = f.path
+          filename   = f.filename
+          size       = f.size
+          upload(folder_name, filename, full_path, size)
+        end
+      end
     end
     # def add_to_folder(file)
     #   folder_name = Discourse.current_hostname
@@ -61,25 +59,25 @@ module DiscourseBackupToDropbox
     # file_difference_remote.dbx.delete("/#{folder_name}/#{filename}") # used dbx, as a method here
 
 #
-#     def upload(folder_name, file_name, full_path, size)
-#       if size < UPLOAD_MAX_SIZE then
-#         dbx.upload("/#{folder_name}/#{file_name}", "#{file_name}")
-#       else
-#         backup.chunked_upload(folder_name, file_name, full_path)
-#       end
-#     end
-#
-#     def chunked_upload(folder_name, file_name, full_path)
-#       File.open(full_path) do |f|
-#         loops = f.size / CHUNK_SIZE
-#         cursor = dbx.start_upload_session(f.read(CHUNK_SIZE))
-#         (loops-1).times do |i|
-#           dbx.append_upload_session( cursor, f.read(CHUNK_SIZE) )
-#         end
-#
-#         dbx.finish_upload_session(cursor, "/#{folder_name}/#{file_name}", f.read(CHUNK_SIZE))
-#       end
-#     end
+    def upload(folder_name, file_name, full_path, size)
+      if size < UPLOAD_MAX_SIZE then
+        dbx.upload("/#{folder_name}/#{file_name}", "#{file_name}")
+      else
+        backup.chunked_upload(folder_name, file_name, full_path)
+      end
+    end
+
+    def chunked_upload(folder_name, file_name, full_path)
+      File.open(full_path) do |f|
+        loops = f.size / CHUNK_SIZE
+        cursor = dbx.start_upload_session(f.read(CHUNK_SIZE))
+        (loops-1).times do |i|
+          dbx.append_upload_session( cursor, f.read(CHUNK_SIZE) )
+        end
+
+        dbx.finish_upload_session(cursor, "/#{folder_name}/#{file_name}", f.read(CHUNK_SIZE))
+      end
+    end
 #
   end
 end

--- a/lib/dropbox_synchronizer.rb
+++ b/lib/dropbox_synchronizer.rb
@@ -18,14 +18,6 @@ module DiscourseBackupToDropbox
     end
 
     protected
-    # def perform_sync
-    #   folder_name = "one"
-    #   dbx.create_folder("/#{folder_name}")
-    #   full_path = backup.path
-    #   filename = backup.filename
-    #   size = backup.size
-    #   upload(folder_name, filename, full_path, size)
-    # end
 
     def perform_sync
       folder_name = Discourse.current_hostname
@@ -35,7 +27,7 @@ module DiscourseBackupToDropbox
         #folder already exists
       end
       dbx_files = dbx.list_folder("/#{folder_name}").map(&:name)
-      (backup.filename - dbx_files).each do |f|
+      ([backup] - dbx_files).each do |f|
         if f.present?
           full_path  = f.path
           filename   = f.filename
@@ -43,22 +35,12 @@ module DiscourseBackupToDropbox
           upload(folder_name, filename, full_path, size)
         end
       end
+      (dbx_files - [backup]).each do |f| # this needs to be tested 
+        dbx.delete("/#{folder_name}/#{filename}")
+      end
     end
-    # def add_to_folder(file)
-    #   folder_name = Discourse.current_hostname
-    #   begin
-    #     folder = dbx.create_folder("/#{folder_name}")
-    #   rescue
-    #     #folder already exists
-    #   end
-    #   folder.add(file)
-    # end
-    #
-    # dropbox_backup_files   = dbx.list_folder("/#{folder_name}").map(&:name)
-    # file_difference_remote = dropbox_backup_files - local_backup_files
-    # file_difference_remote.dbx.delete("/#{folder_name}/#{filename}") # used dbx, as a method here
 
-#
+
     def upload(folder_name, file_name, full_path, size)
       if size < UPLOAD_MAX_SIZE then
         dbx.upload("/#{folder_name}/#{file_name}", "#{file_name}")
@@ -78,6 +60,6 @@ module DiscourseBackupToDropbox
         dbx.finish_upload_session(cursor, "/#{folder_name}/#{file_name}", f.read(CHUNK_SIZE))
       end
     end
-#
+
   end
 end

--- a/lib/dropbox_synchronizer.rb
+++ b/lib/dropbox_synchronizer.rb
@@ -1,7 +1,7 @@
 module DiscourseBackupToDropbox
   class DropboxSynchronizer < Synchronizer
-    CHUNK_SIZE = 25600000
-    UPLOAD_MAX_SIZE = CHUNK_SIZE * 4
+    CHUNK_SIZE ||= 25600000
+    UPLOAD_MAX_SIZE ||= CHUNK_SIZE * 4
 
     def initialize(backup)
       super(backup)
@@ -18,25 +18,34 @@ module DiscourseBackupToDropbox
     end
 
     protected
+    # def perform_sync
+    #   folder_name = "one"
+    #   dbx.create_folder("/#{folder_name}")
+    #   full_path = backup.path
+    #   filename = backup.filename
+    #   size = backup.size
+    #   upload(folder_name, filename, full_path, size)
+    # end
+
     def perform_sync
-      puts "#####################################################"
       folder_name = Discourse.current_hostname
       begin
         dbx.create_folder("/#{folder_name}")
       rescue
         #folder already exists
       end
-      dbx_files = dbx.list_folder("/#{folder_name}")
-      (backup - dbx_files).each do |f|
-        # if f.present?
-          full_path  = f.path
-          filename   = f.filename
-          size       = f.size
-          upload(folder_name, filename, full_path, size)
-        # end
-      end
+      file_name = backup.filename
+      dbx.upload("/#{folder_name}/#{file_name}", "#{file_name}")
+      # dbx_files = dbx.list_folder("/#{folder_name}")
+      # (backup - dbx_files).each do |f|
+      #   # if f.present?
+      #     full_path  = f.path
+      #     filename   = f.filename
+      #     size       = f.size
+      #     upload(folder_name, filename, full_path, size)
+      #   # end
+      # end
     end
-
     # def add_to_folder(file)
     #   folder_name = Discourse.current_hostname
     #   begin
@@ -51,26 +60,26 @@ module DiscourseBackupToDropbox
     # file_difference_remote = dropbox_backup_files - local_backup_files
     # file_difference_remote.dbx.delete("/#{folder_name}/#{filename}") # used dbx, as a method here
 
-
-    def upload(folder_name, file_name, full_path, size)
-      if size < UPLOAD_MAX_SIZE then
-        dbx.upload("/#{folder_name}/#{file_name}", File.open(full_path, "r"))
-      else
-        backup.chunked_upload(folder_name, file_name, full_path)
-      end
-    end
-
-    def chunked_upload(folder_name, file_name, full_path)
-      File.open(full_path) do |f|
-        loops = f.size / CHUNK_SIZE
-        cursor = dbx.start_upload_session(f.read(CHUNK_SIZE))
-        (loops-1).times do |i|
-          dbx.append_upload_session( cursor, f.read(CHUNK_SIZE) )
-        end
-
-        dbx.finish_upload_session(cursor, "/#{folder_name}/#{file_name}", f.read(CHUNK_SIZE))
-      end
-    end
-
+#
+#     def upload(folder_name, file_name, full_path, size)
+#       if size < UPLOAD_MAX_SIZE then
+#         dbx.upload("/#{folder_name}/#{file_name}", "#{file_name}")
+#       else
+#         backup.chunked_upload(folder_name, file_name, full_path)
+#       end
+#     end
+#
+#     def chunked_upload(folder_name, file_name, full_path)
+#       File.open(full_path) do |f|
+#         loops = f.size / CHUNK_SIZE
+#         cursor = dbx.start_upload_session(f.read(CHUNK_SIZE))
+#         (loops-1).times do |i|
+#           dbx.append_upload_session( cursor, f.read(CHUNK_SIZE) )
+#         end
+#
+#         dbx.finish_upload_session(cursor, "/#{folder_name}/#{file_name}", f.read(CHUNK_SIZE))
+#       end
+#     end
+#
   end
 end

--- a/lib/dropbox_synchronizer.rb
+++ b/lib/dropbox_synchronizer.rb
@@ -19,25 +19,38 @@ module DiscourseBackupToDropbox
 
     protected
     def perform_sync
-      full_path  = backup.path
-      filename   = backup.filename
-      size       = backup.size
-      file       = upload(filename, full_path, size)
-      add_to_folder(file)
-      dropbox_backup_files   = dbx.list_folder("/#{folder_name}").map(&:name)
-      file_difference_remote = dropbox_backup_files - local_backup_files
-      file_difference_remote.dbx.delete("/#{folder_name}/#{filename}") # used dbx, as a method here
-    end
-
-    def add_to_folder(file)
+      puts "#####################################################"
       folder_name = Discourse.current_hostname
       begin
-        folder = dbx.create_folder("/#{folder_name}")
+        dbx.create_folder("/#{folder_name}")
       rescue
         #folder already exists
       end
-      folder.add(file)
-    end                                                                  # and took out the loop
+      dbx_files = dbx.list_folder("/#{folder_name}")
+      (backup - dbx_files).each do |f|
+        # if f.present?
+          full_path  = f.path
+          filename   = f.filename
+          size       = f.size
+          upload(folder_name, filename, full_path, size)
+        # end
+      end
+    end
+
+    # def add_to_folder(file)
+    #   folder_name = Discourse.current_hostname
+    #   begin
+    #     folder = dbx.create_folder("/#{folder_name}")
+    #   rescue
+    #     #folder already exists
+    #   end
+    #   folder.add(file)
+    # end
+    #
+    # dropbox_backup_files   = dbx.list_folder("/#{folder_name}").map(&:name)
+    # file_difference_remote = dropbox_backup_files - local_backup_files
+    # file_difference_remote.dbx.delete("/#{folder_name}/#{filename}") # used dbx, as a method here
+
 
     def upload(folder_name, file_name, full_path, size)
       if size < UPLOAD_MAX_SIZE then

--- a/plugin.rb
+++ b/plugin.rb
@@ -6,14 +6,11 @@
 
 gem 'public_suffix', '2.0.5', {require: false }
 gem 'domain_name', '0.5.20170404', {require: false }
-
 gem 'addressable', '2.5.1', {require: false }
 gem 'http_parser.rb', '0.6.0', {require: false }
 gem 'http-cookie', '1.0.3', {require: false }
 gem 'http-form_data', '1.0.1', {require: false }
-
 gem 'http', '2.0.3', {require: false }
-
 gem 'dropbox-sdk-v2', '0.0.3', { require: false }
 
 enabled_site_setting :discourse_sync_to_dropbox_enabled
@@ -21,10 +18,8 @@ enabled_site_setting :discourse_sync_to_dropbox_enabled
 require 'dropbox'
 
 after_initialize do
-
   load File.expand_path("../app/jobs/regular/sync_backups_to_dropbox.rb", __FILE__)
   load File.expand_path("../lib/dropbox_synchronizer.rb", __FILE__)
-
 
   Backup.class_eval do
     def after_create_hook
@@ -32,4 +27,3 @@ after_initialize do
     end
   end
 end
-


### PR DESCRIPTION
The perform_sync method checks if each backup from SiteSetting.discourse_sync_to_dropbox_quantity exists in Dropbox before uploading to avoid storing duplicate files.

