### PR TITLE
move delete method to job

### DIFF
--- a/app/jobs/regular/sync_backups_to_dropbox.rb
+++ b/app/jobs/regular/sync_backups_to_dropbox.rb
@@ -1,5 +1,3 @@
-require_relative '../../../lib/dropbox_synchronizer.rb'
-
 module Jobs
   class SyncBackupsToDropbox < ::Jobs::Base
 

--- a/app/jobs/regular/sync_backups_to_dropbox.rb
+++ b/app/jobs/regular/sync_backups_to_dropbox.rb
@@ -8,6 +8,7 @@ module Jobs
       backups.each do |backup|
         DiscourseBackupToDropbox::DropboxSynchronizer.new(backup).sync
       end
+      DiscourseBackupToDropbox::DropboxSynchronizer.delete_old_files
     end
   end
 end

--- a/app/jobs/regular/sync_backups_to_dropbox.rb
+++ b/app/jobs/regular/sync_backups_to_dropbox.rb
@@ -1,3 +1,5 @@
+require_relative '../../../lib/dropbox_synchronizer.rb'
+
 module Jobs
   class SyncBackupsToDropbox < ::Jobs::Base
 
@@ -8,7 +10,7 @@ module Jobs
       backups.each do |backup|
         DiscourseBackupToDropbox::DropboxSynchronizer.new(backup).sync
       end
-      DiscourseBackupToDropbox::DropboxSynchronizer.delete_old_files
+      DiscourseBackupToDropbox::DropboxSynchronizer.new(backups).delete_old_files
     end
   end
 end

--- a/lib/dropbox_synchronizer.rb
+++ b/lib/dropbox_synchronizer.rb
@@ -28,7 +28,6 @@ module DiscourseBackupToDropbox
       end
       dbx_files = dbx.list_folder("/#{folder_name}")
       upload_unique_files(folder_name, dbx_files)
-      delete_old_files
     end
 
     def upload_unique_files(folder_name, dbx_files)
@@ -44,11 +43,10 @@ module DiscourseBackupToDropbox
 
     def delete_old_files
       folder_name = Discourse.current_hostname
-      dbx_files = dbx.list_folder("/#{folder_name}")
-      sorted = dbx_files.sort_by {|x| x.server_modified}
-      keep = sorted.take(SiteSetting.discourse_sync_to_dropbox_quantity)
+      dbx_files = dbx.list_folder("/#{folder_name}").map(&:name).reverse!
+      keep = dbx_files.take(SiteSetting.discourse_sync_to_dropbox_quantity)
       trash = dbx_files - keep
-      trash.each {|f| dbx.delete("#{f.path_lower}")}
+      trash.each {|f| dbx.delete("/#{folder_name}/#{f}")}
     end
 
     def upload(folder_name, file_name, full_path, size)

--- a/lib/dropbox_synchronizer.rb
+++ b/lib/dropbox_synchronizer.rb
@@ -17,6 +17,14 @@ module DiscourseBackupToDropbox
       @turned_on && @api_key.present? && backup.present?
     end
 
+    def delete_old_files
+      folder_name = Discourse.current_hostname
+      dbx_files = dbx.list_folder("/#{folder_name}").map(&:name).reverse!
+      keep = dbx_files.take(SiteSetting.discourse_sync_to_dropbox_quantity)
+      trash = dbx_files - keep
+      trash.each {|f| dbx.delete("/#{folder_name}/#{f}")}
+    end
+
     protected
 
     def perform_sync
@@ -39,14 +47,6 @@ module DiscourseBackupToDropbox
           upload(folder_name, filename, full_path, size)
         end
       end
-    end
-
-    def delete_old_files
-      folder_name = Discourse.current_hostname
-      dbx_files = dbx.list_folder("/#{folder_name}").map(&:name).reverse!
-      keep = dbx_files.take(SiteSetting.discourse_sync_to_dropbox_quantity)
-      trash = dbx_files - keep
-      trash.each {|f| dbx.delete("/#{folder_name}/#{f}")}
     end
 
     def upload(folder_name, file_name, full_path, size)

--- a/plugin.rb
+++ b/plugin.rb
@@ -11,14 +11,12 @@ gem 'addressable', '2.5.1', {require: false }
 gem 'http_parser.rb', '0.6.0', {require: false }
 gem 'http-cookie', '1.0.3', {require: false }
 gem 'http-form_data', '1.0.1', {require: false }
-
 gem 'http', '2.0.3', {require: false }
-
 gem 'dropbox-sdk-v2', '0.0.3', { require: false }
+require 'dropbox'
+require 'sidekiq'
 
 enabled_site_setting :discourse_sync_to_dropbox_enabled
-
-require 'dropbox'
 
 after_initialize do
 
@@ -32,4 +30,3 @@ after_initialize do
     end
   end
 end
-


### PR DESCRIPTION
delete_old_files method is not protected anymore, so it can be called from the Job.
Changed the delete method to be executed only once per Job, and not once per backup.
delete_old_files uses .map(&:name) and works together with dbx.delete("/#{folder_name}/#{f}")
I've used map by name because it's way easier to visualise in the console and it doesn't affect the behavior of the deletion.
It works like charm!